### PR TITLE
made event listening optional

### DIFF
--- a/src/main/java/hyperledger/besu/java/rest/client/config/EthEventsProperties.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/config/EthEventsProperties.java
@@ -1,3 +1,10 @@
+/**
+ * This file is reading the Event Listening Configuration
+ *
+ * @since 1.0
+ * @author kamini-kamal
+ * @version 1.0
+ */
 package hyperledger.besu.java.rest.client.config;
 
 import hyperledger.besu.java.rest.client.exception.ErrorCode;
@@ -8,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Configuration;
@@ -16,28 +24,45 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConfigurationProperties(prefix = "events")
 @RefreshScope
+@Slf4j
 public class EthEventsProperties {
+  /** This is used to enable block listening event. */
   private boolean block;
+  /** This is used to capture smart-contract address and abiBasePath. */
   private SmartContract smartContract;
+
+  /** Captures event name and hash generated from Abi definition. */
   private static Map<String, String> eventNameByHash = new HashMap<>();
 
   @Data
   public static class SmartContract {
+    /** captures smart-contract address. */
     private List<String> addresses;
+    /** captures abi file base path. */
     private String abiBasePath;
   }
 
+  /** after the configuration is loaded, hash is generated for events. */
   @PostConstruct
   public void generateEventHashFromAbiFile() {
-    eventNameByHash = SmartContractUtility.generateEventHashFromAbiFiles(smartContract);
+    eventNameByHash = SmartContractUtility.getEventHashFromAbi(smartContract);
+    log.info("eventNameByHash {}", eventNameByHash);
   }
 
-  public static String getEventHasStringForSmartContractAddress(String incomingEventHash) {
+  /** @return */
+  public static Map<String, String> getEventNameByHash() {
+    return eventNameByHash;
+  }
+
+  /**
+   * @param incomingEventHash
+   * @return event name from hash
+   */
+  public static String getEventHasForSCAddress(final String incomingEventHash) {
     if (eventNameByHash.containsKey(incomingEventHash)) {
       return eventNameByHash.get(incomingEventHash);
     } else {
-      throw new NotFoundException(
-          ErrorCode.NO_EVENTS_FOUND, "No Events found for hash " + incomingEventHash);
+      throw new NotFoundException(ErrorCode.NO_EVENTS_FOUND, incomingEventHash);
     }
   }
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/config/package-info.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/config/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * This module is about loading of the application configurations.
+ *
+ * <p>This module reads the configs and creates specific Beans.
+ *
+ * <p>The Beans can be refreshed at runtime.
+ *
+ * @since 1.0
+ * @author kamini-kamal
+ * @version 1.1
+ */
+package hyperledger.besu.java.rest.client.config;

--- a/src/main/java/hyperledger/besu/java/rest/client/filters/ReplayFilterHandler.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/filters/ReplayFilterHandler.java
@@ -7,46 +7,63 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.core.DefaultBlockParameter;
 
+/**
+ * This class is for the future scope, this is currently not
+ *
+ * <p>attached to the event listeners.
+ */
 @Service
 @Slf4j
-// This class is for the future scope, this is currently not attached to the event listeners
 public class ReplayFilterHandler {
+
+  /** Loads the eth-connector config. */
   @Autowired private EthConfig ethConfig;
 
-  // replay all blocks up to the most current, and provide notification (via the submitted Flowable)
-  // once you've caught up:
+  /**
+   * @param startBlock
+   * @param endBlock
+   * @param fullTxObj
+   * @param asc
+   */
   @Async
   public void replayPastBlocksFlowable(
-      DefaultBlockParameter startBlockNumber,
-      DefaultBlockParameter endBlockNumber,
-      boolean fullTxObjects,
-      boolean ascending) {
+      final DefaultBlockParameter startBlock,
+      final DefaultBlockParameter endBlock,
+      final boolean fullTxObj,
+      final boolean asc) {
     ethConfig
         .getWeb3jList()
         .get(0)
-        .replayPastBlocksFlowable(startBlockNumber, endBlockNumber, fullTxObjects, ascending)
+        .replayPastBlocksFlowable(startBlock, endBlock, fullTxObj, asc)
         .doOnError(
-            error ->
-                log.error(
-                    "Error occurred while listening to replayPastBlocksFlowable events"
-                        + error.getMessage()))
-        .subscribe(block -> {});
+            error -> {
+              log.error("Error listening to past block" + error.getMessage());
+            })
+        .subscribe(
+            block -> {
+              log.info("Listening to past block");
+            });
   }
 
-  // replay all blocks to the most current, then be notified of new subsequent blocks being created:
+  /**
+   * @param sBlk
+   * @param txn
+   */
   @Async
   public void replayPastAndFutureBlocksFlowable(
-      DefaultBlockParameter startBlockNumber, boolean fullTxObjects) {
+      final DefaultBlockParameter sBlk, final boolean txn) {
 
     ethConfig
         .getWeb3jList()
         .get(0)
-        .replayPastAndFutureBlocksFlowable(startBlockNumber, fullTxObjects)
+        .replayPastAndFutureBlocksFlowable(sBlk, txn)
         .doOnError(
-            error ->
-                log.error(
-                    "Error occurred while listening to replayPastAndFutureBlocks events"
-                        + error.getMessage()))
-        .subscribe(block -> {});
+            e -> {
+              log.error("Error in past and future events" + e.getMessage());
+            })
+        .subscribe(
+            block -> {
+              log.info("Listening to past-future block");
+            });
   }
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/filters/TransactionFilterHandler.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/filters/TransactionFilterHandler.java
@@ -7,58 +7,70 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.core.DefaultBlockParameter;
 
+/**
+ * This class is for the future scope,
+ *
+ * <p>this is currently not attached to
+ *
+ * <p>the event listeners.
+ */
 @Service
 @Slf4j
-// This class is for the future scope, this is currently not attached to the event listeners
 public class TransactionFilterHandler {
+  /** Loads the eth-connector config. */
   @Autowired private EthConfig ethConfig;
 
-  // To receive all new transactions as they are added to the blockchain:
+  /** To receive all new transactions as they are added to the blockchain. */
   @Async
-  public void receiveAllNewTransaction() {
+  public void receiveNewTxn() {
 
     ethConfig
         .getWeb3jList()
         .get(0)
         .transactionFlowable()
         .doOnError(
-            error ->
-                log.error(
-                    "Error occurred while listening to receiveAllNewTransaction events"
-                        + error.getMessage()))
-        .subscribe(tx -> {});
+            err -> {
+              log.error("Error listening to new txn" + err.getMessage());
+            })
+        .subscribe(
+            tx -> {
+              log.info("Listening to new transactions events");
+            });
   }
 
-  // To receive all pending transactions as they are submitted to the network (i.e. before they have
-  // been grouped into a block together):
+  /** To receive all pending transactions. */
   @Async
-  public void receiveAllPendingTransactions() {
+  public void receivePendingTxn() {
 
     ethConfig
         .getWeb3jList()
         .get(0)
         .pendingTransactionFlowable()
         .doOnError(
-            error ->
-                log.error(
-                    "Error occurred while listening to receiveAllPendingTransactions events"
-                        + error.getMessage()))
-        .subscribe(tx -> {});
+            err -> {
+              log.error("Error listening to pending txn" + err.getMessage());
+            })
+        .subscribe(
+            tx -> {
+              log.info("Listening to pending transactions events");
+            });
   }
 
-  // Replay all blocks to the most current, but with transactions contained within blocks:
+  /** @param startBlock */
   @Async
-  public void replayPastAndFutureTransactions(DefaultBlockParameter startBlock) {
+  public void replayPastAndFutureTxn(final DefaultBlockParameter startBlock) {
 
     ethConfig
         .getWeb3jList()
         .get(0)
         .replayPastAndFutureTransactionsFlowable(startBlock)
         .doOnError(
-            error ->
-                log.error(
-                    "Error occurred while listening to replayPastAndFutureTransactions events"
-                        + error.getMessage()))
-        .subscribe(tx -> {});
+            err -> {
+              log.error("Error in past-future event" + err.getMessage());
+            })
+        .subscribe(
+            tx -> {
+              log.info("Listening to  past and future events");
+            });
   }
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/filters/package-info.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/filters/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * This module is about creating filters for event filtering.
+ *
+ * <p>This module reads the configs and creates specific Beans.
+ *
+ * <p>They contain asynchronous methods.
+ *
+ * @since 1.0
+ * @author kamini-kamal
+ * @version 1.1
+ */
+package hyperledger.besu.java.rest.client.filters;

--- a/src/main/java/hyperledger/besu/java/rest/client/listener/BlockEventListener.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/listener/BlockEventListener.java
@@ -11,14 +11,15 @@ import org.springframework.stereotype.Service;
 @Service
 @ConditionalOnProperty(value = "events.block", havingValue = "true")
 public class BlockEventListener implements Runnable {
-
+  /** Loads the eth-connector config. */
   @Autowired private EthConfig ethConfig;
+
+  /** Loads the block filter service. */
   @Autowired private BlockFilterHandler blockFilterHandler;
 
+  /** todo: Improve the logic to include all nodes from the network. */
   @Override
   public void run() {
-    // TODO: Improve the logic to include all nodes from the network
-    // get events with all transactions data
     blockFilterHandler.receiveNewlyAddedBlocksOnly();
   }
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/listener/SmartContractEventListener.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/listener/SmartContractEventListener.java
@@ -2,28 +2,32 @@ package hyperledger.besu.java.rest.client.listener;
 
 import hyperledger.besu.java.rest.client.config.EthConfig;
 import hyperledger.besu.java.rest.client.config.EthEventsProperties;
-import hyperledger.besu.java.rest.client.exception.ErrorCode;
-import hyperledger.besu.java.rest.client.exception.NotFoundException;
 import hyperledger.besu.java.rest.client.filters.TopicFilterHandler;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
-@Scope("prototype")
+@Service
 public class SmartContractEventListener implements Runnable {
+  /** Loads the eth-connector config. */
   @Autowired private EthConfig ethConfig;
-  @Autowired private TopicFilterHandler topicFilterHandler;
-  @Autowired private EthEventsProperties ethEventsProperties;
 
+  /** Loads the topic-filter service. */
+  @Autowired private TopicFilterHandler topicFilterHandler;
+
+  /** Loads the event-properties config. */
+  @Autowired(required = false)
+  private EthEventsProperties ethEventsProperties;
+
+  /**
+   * This run method will be called by AsyncEventListener
+   *
+   * <p>after successful Bean creation.
+   */
   @Override
   public void run() {
-    // only use smartContract address
-    if (ObjectUtils.isEmpty(ethEventsProperties.getSmartContract())
-        && ObjectUtils.isEmpty(ethEventsProperties.getSmartContract().getAddresses())) {
-      throw new NotFoundException(ErrorCode.NOT_FOUND, "Smart Contract Address list is empty");
+    if (ObjectUtils.isNotEmpty(EthEventsProperties.getEventNameByHash())) {
+      topicFilterHandler.receiveAllEventsByEthFilter();
     }
-    topicFilterHandler.receiveAllEventsByEthFilter();
   }
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/listener/package-info.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/listener/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * This module is about creating filters for event listening.
+ *
+ * <p>This module reads the configs and creates specific Beans.
+ *
+ * <p>They override Runnable Interface.
+ *
+ * @since 1.0
+ * @author kamini-kamal
+ * @version 1.1
+ */
+package hyperledger.besu.java.rest.client.listener;

--- a/src/main/java/hyperledger/besu/java/rest/client/model/events/SCEventWrapper.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/model/events/SCEventWrapper.java
@@ -10,8 +10,13 @@ import org.web3j.protocol.core.methods.response.Log;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class SmartContractEventWrapper {
+public class SCEventWrapper {
+  /** Event name for the SC event. */
   private String eventName;
+
+  /** Data for the SC event. */
   private String data;
+
+  /** Log for the SC event. */
   private Log log;
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/model/events/package-info.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/model/events/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * This module is about event structure.
+ *
+ * <p>This module reads the configs and creates specific Beans.
+ *
+ * @since 1.0
+ * @author kamini-kamal
+ * @version 1.1
+ */
+package hyperledger.besu.java.rest.client.model.events;

--- a/src/main/java/hyperledger/besu/java/rest/client/service/AsyncEventListener.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/service/AsyncEventListener.java
@@ -3,6 +3,7 @@ package hyperledger.besu.java.rest.client.service;
 import hyperledger.besu.java.rest.client.config.EthEventsProperties;
 import hyperledger.besu.java.rest.client.listener.BlockEventListener;
 import hyperledger.besu.java.rest.client.listener.SmartContractEventListener;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -15,25 +16,43 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AsyncEventListener {
 
+  /** using the application context to map the async listeners. */
   @Autowired private ApplicationContext appContext;
 
+  /** This is for concurrrent task. */
   @Autowired private TaskExecutor taskExecutor;
-  @Autowired private EthEventsProperties ethEventsProperties;
 
+  /** using eth-connector events properties. */
+  @Autowired(required = false)
+  private EthEventsProperties ethEventsProps;
+
+  /** creating concurrent task for smart-contract. */
   @EventListener(ApplicationReadyEvent.class)
-  public void smartContractEventListenerThread() {
-    SmartContractEventListener smartContractEventListener =
-        appContext.getBean(SmartContractEventListener.class);
-    taskExecutor.execute(smartContractEventListener);
+  public void sCEventListenerThread() {
+    try {
+      if (Objects.nonNull(ethEventsProps.getEventNameByHash())) {
+        SmartContractEventListener smartContractEventListener =
+            appContext.getBean(SmartContractEventListener.class);
+        taskExecutor.execute(smartContractEventListener);
+        log.info("SmartContract event listening is currently enabled ");
+      }
+    } catch (Exception e) {
+      log.warn("Error while SC event listening {}", e.getMessage());
+    }
   }
 
+  /** creating concurrent task for block-events. */
   @EventListener(ApplicationReadyEvent.class)
-  public void blockEventListenerThread() {
-    if (ethEventsProperties.isBlock()) {
-      BlockEventListener blockEventListener = appContext.getBean(BlockEventListener.class);
-      taskExecutor.execute(blockEventListener);
-    } else {
-      log.info("Block event listening is currently disabled");
+  public void blockEvtListenerThread() {
+    try {
+      if (Objects.nonNull(ethEventsProps) && ethEventsProps.isBlock()) {
+
+        BlockEventListener bkLsr = appContext.getBean(BlockEventListener.class);
+        taskExecutor.execute(bkLsr);
+        log.info("Block event listening is currently enabled ");
+      }
+    } catch (Exception e) {
+      log.warn("Error while Block event listening {}", e.getMessage());
     }
   }
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/service/TopicFilterService.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/service/TopicFilterService.java
@@ -3,5 +3,11 @@ package hyperledger.besu.java.rest.client.service;
 import org.web3j.protocol.core.methods.request.EthFilter;
 
 public interface TopicFilterService {
-  EthFilter createEthFilterWithSmartContractAddressList();
+
+  /**
+   * uses smart-contract address, from and to block.
+   *
+   * @return EthFilter object
+   */
+  EthFilter createEthFilterWithSCAddress();
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/service/impl/TopicFilterServiceImpl.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/service/impl/TopicFilterServiceImpl.java
@@ -3,21 +3,33 @@ package hyperledger.besu.java.rest.client.service.impl;
 import hyperledger.besu.java.rest.client.config.EthEventsProperties;
 import hyperledger.besu.java.rest.client.service.TopicFilterService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
-import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.request.EthFilter;
 
+/** This service is used for Topic filter related tasks. */
 @Service
-// This service is used for Topic filter related tasks
+@ConditionalOnProperty(
+    prefix = "events.smartContract",
+    name = {"addresses", "abiBasePath"},
+    matchIfMissing = true)
 public class TopicFilterServiceImpl implements TopicFilterService {
-  private static final DefaultBlockParameter fromBlock =
-      DefaultBlockParameterName.EARLIEST; // optional, params - defaults to latest for both
-  private static final DefaultBlockParameter toBlock = DefaultBlockParameterName.LATEST;
-  @Autowired private EthEventsProperties ethEventsProperties;
 
+  /** used when the event configs are present. */
+  @Autowired(required = false)
+  private EthEventsProperties ethEvtProp;
+
+  /**
+   * used for creating eth filter for sc-addresses, from and to block.
+   *
+   * @return the ethFilter object
+   */
   @Override
-  public EthFilter createEthFilterWithSmartContractAddressList() {
-    return new EthFilter(fromBlock, toBlock, ethEventsProperties.getSmartContract().getAddresses());
+  public EthFilter createEthFilterWithSCAddress() {
+    return new EthFilter(
+        DefaultBlockParameterName.EARLIEST,
+        DefaultBlockParameterName.LATEST,
+        ethEvtProp.getSmartContract().getAddresses());
   }
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/service/impl/package-info.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/service/impl/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * This module is implementation of handling incoming events.
+ *
+ * @since 1.0
+ * @author kamini-kamal
+ * @version 1.1
+ */
+package hyperledger.besu.java.rest.client.service.impl;

--- a/src/main/java/hyperledger/besu/java/rest/client/service/package-info.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/service/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * This module is about handling incoming events.
+ *
+ * @since 1.0
+ * @author kamini-kamal
+ * @version 1.1
+ */
+package hyperledger.besu.java.rest.client.service;

--- a/src/main/java/hyperledger/besu/java/rest/client/utils/SmartContractUtility.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/utils/SmartContractUtility.java
@@ -1,11 +1,11 @@
 package hyperledger.besu.java.rest.client.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hyperledger.besu.java.rest.client.config.EthEventsProperties;
 import hyperledger.besu.java.rest.client.exception.ErrorCode;
 import hyperledger.besu.java.rest.client.exception.FileParseException;
-import hyperledger.besu.java.rest.client.exception.InvalidArgumentException;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -15,93 +15,171 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.maven.surefire.shade.org.apache.commons.io.IOUtils;
 import org.springframework.util.ResourceUtils;
 import org.web3j.abi.EventEncoder;
-import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.AbiTypes;
 import org.web3j.abi.datatypes.Event;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.protocol.core.methods.response.AbiDefinition;
 
 @UtilityClass
+@Slf4j
 public class SmartContractUtility {
 
+  /** used to specify abi events from the definition. */
   private static final String ABI_TYPE_EVENT = "event";
-  private static final ObjectMapper mapper = new ObjectMapper();
 
-  public String convertToStringFromHex(String hexString)
+  /** used to serialize and deserialize the definitions. */
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  /** used to remove first two chars of hex string. */
+  private static final int DATA_STRING_HEX_FORMAT_START_IDX = 2;
+
+  /**
+   * @param hexStr
+   * @return the data string
+   * @throws DecoderException
+   * @throws UnsupportedEncodingException
+   */
+  public String convertToStringFromHex(final String hexStr)
       throws DecoderException, UnsupportedEncodingException {
-    byte[] bytes = Hex.decodeHex(hexString.substring(2).toCharArray());
+    byte[] bytes = Hex.decodeHex(hexStr.substring(2).toCharArray());
     return new String(bytes, "UTF-8");
   }
 
-  public Map<String, String> generateEventHashFromAbiFiles(
-      EthEventsProperties.SmartContract smartContract) {
+  /**
+   * @param smrtContractObj
+   * @return the hashmap of events and hash
+   */
+  public Map<String, String> getEventHashFromAbi(
+      final EthEventsProperties.SmartContract smrtContractObj) {
     Map<String, String> eventNameByHash = new HashMap<>();
-    List<String> abiFileList = getAbiFilePathListForSmartContract(smartContract);
-    abiFileList.stream().forEach(abiFilePath -> addEventNameByHash(abiFilePath, eventNameByHash));
-    return eventNameByHash;
+    if (Objects.nonNull(smrtContractObj)
+        && ObjectUtils.allNotNull(
+            smrtContractObj.getAbiBasePath(), smrtContractObj.getAddresses())) {
+
+      List<String> abiList = getAbiPathListForSmartContract(smrtContractObj);
+      abiList.stream()
+          .forEach(
+              abiPathSmrtContractAddr -> {
+                try {
+                  addEventNameByHash(abiPathSmrtContractAddr, eventNameByHash);
+                } catch (UnsupportedEncodingException e) {
+                  log.error("Error while reading file {}", e.getMessage());
+                }
+              });
+      return eventNameByHash;
+    }
+    log.info("Data related to SmartContract Event is missing");
+    return null;
   }
 
-  private static TypeReference<? extends Type> getEventFuncParameters(
-      String type, boolean indexed) {
+  /**
+   * @param type
+   * @param indexed
+   * @return type references for the classes
+   */
+  private static org.web3j.abi.TypeReference<? extends Type> getEvtFuncRef(
+      final String type, final boolean indexed) {
     Class clazz = AbiTypes.getType(type);
-    return TypeReference.create(clazz, indexed);
+    return org.web3j.abi.TypeReference.create(clazz, indexed);
   }
 
-  private static List<String> getAbiFilePathListForSmartContract(
-      EthEventsProperties.SmartContract smartContract) {
+  /**
+   * @param smartContract
+   * @return the abi file list
+   */
+  private static List<String> getAbiPathListForSmartContract(
+      final EthEventsProperties.SmartContract smartContract) {
     List<String> abiFileList = new ArrayList<>();
     String baseAbiPath = smartContract.getAbiBasePath();
     smartContract.getAddresses().stream()
-        .forEach(address -> getAbiListForSmartContracts(baseAbiPath, address, abiFileList));
+        .forEach(
+            abiPathSmartContractAddress ->
+                getAbiFileListForSmartContracts(
+                    baseAbiPath, abiPathSmartContractAddress, abiFileList));
     return abiFileList;
   }
 
-  private void getAbiListForSmartContracts(
-      String baseAbiPath, String parentFolderName, List<String> abiFileList) {
-    String smartContractPath = baseAbiPath + parentFolderName;
-    File[] abiFiles = new File(smartContractPath).listFiles();
-    Arrays.stream(abiFiles)
-        .forEach(file -> abiFileList.add(smartContractPath + "/" + file.getName()));
+  /**
+   * @param aboBasePath
+   * @param parentFolderNameForSCAddress
+   * @param abiPathFileList
+   */
+  private void getAbiFileListForSmartContracts(
+      final String aboBasePath,
+      final String parentFolderNameForSCAddress,
+      final List<String> abiPathFileList) {
+    String addressPath = aboBasePath + parentFolderNameForSCAddress;
+    try {
+      File[] abiFiles = new File(addressPath).listFiles();
+      Arrays.stream(abiFiles)
+          .forEach(
+              filePath -> {
+                abiPathFileList.add(addressPath + "/" + filePath.getName());
+              });
+    } catch (Exception e) {
+      log.error(ErrorCode.FILE_PARSE_ERROR.getReason(), e.getMessage());
+    }
   }
 
-  private void addEventNameByHash(String abiFilePath, Map<String, String> eventNameByHash) {
-    byte[] expectedTemplate;
+  /**
+   * @param abiPath
+   * @param eventNameHexMapping
+   */
+  private void addEventNameByHash(
+      final String abiPath, final Map<String, String> eventNameHexMapping)
+      throws UnsupportedEncodingException {
+    byte[] abiFileDefinition;
     try {
-      expectedTemplate = IOUtils.toByteArray(ResourceUtils.getURL(abiFilePath));
+      abiFileDefinition = IOUtils.toByteArray(ResourceUtils.getURL(abiPath));
     } catch (IOException e) {
       throw new FileParseException(ErrorCode.FILE_PARSE_ERROR, e.getMessage());
     }
-    String abiString = new String(expectedTemplate, StandardCharsets.UTF_8);
+    String abiDefinitionForSmartContractAddressStringified =
+        new String(abiFileDefinition, StandardCharsets.UTF_8);
     try {
-      mapper
+      OBJECT_MAPPER
           .readValue(
-              abiString,
-              new com.fasterxml.jackson.core.type.TypeReference<List<AbiDefinition>>() {})
+              abiDefinitionForSmartContractAddressStringified,
+              new TypeReference<List<AbiDefinition>>() { })
           .stream()
-          .forEach(abiDef -> createEventDefinition(abiDef, eventNameByHash));
+          .forEach(
+              abiDefinition -> {
+                createEventDefinition(abiDefinition, eventNameHexMapping);
+              });
 
     } catch (JsonProcessingException e) {
-      throw new InvalidArgumentException(ErrorCode.INVALID_ARGUMENT_FOUND, e.getMessage());
+      log.error("Unable to read Abi file", e.getMessage());
     }
   }
 
-  private void createEventDefinition(AbiDefinition abiDef, Map<String, String> eventNameByHash) {
+  /**
+   * @param abiDef
+   * @param evtByHash
+   */
+  private void createEventDefinition(
+      final AbiDefinition abiDef, final Map<String, String> evtByHash) {
     List<org.web3j.abi.TypeReference<?>> parameters = new ArrayList<>();
     if (abiDef.getType().equals(ABI_TYPE_EVENT)) {
       abiDef.getInputs().stream()
           .forEach(
-              input ->
-                  parameters.add(
-                      getEventFuncParameters(input.getInternalType(), input.isIndexed())));
+              abiDefinitionInputParameter -> {
+                parameters.add(
+                    getEvtFuncRef(
+                        abiDefinitionInputParameter.getInternalType(),
+                        abiDefinitionInputParameter.isIndexed()));
+              });
       Event event = new Event(abiDef.getName(), parameters);
       String eventHash = EventEncoder.encode(event);
-      eventNameByHash.put(eventHash, abiDef.getName());
+      evtByHash.put(eventHash, abiDef.getName());
     }
   }
 }

--- a/src/main/java/hyperledger/besu/java/rest/client/utils/package-info.java
+++ b/src/main/java/hyperledger/besu/java/rest/client/utils/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * This module is about utilities.
+ *
+ * <p>This module is used by the respective
+ *
+ * <p>configs or services as helper class.
+ *
+ * @since 1.0
+ * @author kamini-kamal
+ * @version 1.1
+ */
+package hyperledger.besu.java.rest.client.utils;


### PR DESCRIPTION
Made event listening for eth connector optional

The following use-cases have been covered as a part of this fix:

- If SmartContract is not present, no listener will be created
- If SmartContract and abi file mapping doesnot happen and overall outcome is null (not a single mapping exists), no listener will be attached
- If out of N abiFiles, x files are corrupt, the code works for N-x files and application will log errors for the x files but application execution will not fail
- Any duplicate abiFiles will be filtered out using hash of the functions getting generated after reading through the abiFiles (JSON format only)
- If the block event is false or doesn't exist, the listener will not be created
- If the event-listening for kafka endpoints are not present, the application bootstrap will not fail since its marked as optional
- Event Listening is an optional feature and doesn't impact the REST APIs